### PR TITLE
Add meng calc

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,11 @@
 
   <section id="results">
     <div>
+      <h2>Degree:</h2>
+      <input class="degree" id="meng" type="radio" tabindex="1" name="degree" value="meng"><label for="meng">MEng</label>
+      <input class="degree" id="bsc" type="radio" tabindex="2" name="degree" value="bsc" checked><label for="bsc">BSc</label>
+    </div>
+    <div>
       <h2>Indication:</h2>
       <p id="finalClassification">not enough data</span>.</p>
     </div>
@@ -40,53 +45,77 @@
   <section id="l5">
     <h2>Second Year</h2>
     <div class="module">
-      <input id="l5mark1" type="number" min="0" max="100" tabindex="1" placeholder="0" autofocus>
-      <input id="l5name1" type="text" tabindex="21" placeholder="module 1 name">
+      <input id="l5mark1" type="number" min="0" max="100" tabindex="3" placeholder="0" autofocus>
+      <input id="l5name1" type="text" tabindex="4" placeholder="module 1 name">
     </div>
     <div class="module">
-      <input id="l5mark2" type="number" min="0" max="100" tabindex="2" placeholder="0">
-      <input id="l5name2" type="text" tabindex="22" placeholder="module 2 name">
+      <input id="l5mark2" type="number" min="0" max="100" tabindex="5" placeholder="0">
+      <input id="l5name2" type="text" tabindex="6" placeholder="module 2 name">
     </div>
     <div class="module">
-      <input id="l5mark3" type="number" min="0" max="100" tabindex="3" placeholder="0">
-      <input id="l5name3" type="text" tabindex="23" placeholder="module 3 name">
+      <input id="l5mark3" type="number" min="0" max="100" tabindex="7" placeholder="0">
+      <input id="l5name3" type="text" tabindex="8" placeholder="module 3 name">
     </div>
     <div class="module">
-      <input id="l5mark4" type="number" min="0" max="100" tabindex="4" placeholder="0">
-      <input id="l5name4" type="text" tabindex="24" placeholder="module 4 name">
+      <input id="l5mark4" type="number" min="0" max="100" tabindex="9" placeholder="0">
+      <input id="l5name4" type="text" tabindex="10" placeholder="module 4 name">
     </div>
     <div class="module">
-      <input id="l5mark5" type="number" min="0" max="100" tabindex="5" placeholder="0">
-      <input id="l5name5" type="text" tabindex="25" placeholder="module 5 name">
+      <input id="l5mark5" type="number" min="0" max="100" tabindex="11" placeholder="0">
+      <input id="l5name5" type="text" tabindex="12" placeholder="module 5 name">
     </div>
     <div class="module">
-      <input id="l5mark6" type="number" min="0" max="100" tabindex="6" placeholder="0">
-      <input id="l5name6" type="text" tabindex="26" placeholder="module 6 name">
+      <input id="l5mark6" type="number" min="0" max="100" tabindex="13" placeholder="0">
+      <input id="l5name6" type="text" tabindex="14" placeholder="module 6 name">
     </div>
   </section>
 
 
   <section id="l6">
+    <h2 id="l6year">Final Year</h2>
+    <div class="module">
+      <input id="l6mark1" type="number" tabindex="15" min="0" max="100" placeholder="0">
+      <input id="l6name1" type="text" tabindex="16" placeholder="module name">
+    </div>
+    <div class="module">
+      <input id="l6mark2" type="number" tabindex="17" min="0" max="100" placeholder="0">
+      <input id="l6name2" type="text" tabindex="18" placeholder="module name">
+    </div>
+    <div class="module">
+      <input id="l6mark3" type="number" tabindex="19" min="0" max="100" placeholder="0">
+      <input id="l6name3" type="text" tabindex="20" placeholder="module name">
+    </div>
+    <div class="module">
+      <input id="l6mark4" type="number" tabindex="21" min="0" max="100" placeholder="0">
+      <input id="l6name4" type="text" tabindex="22" placeholder="module name">
+    </div>
+    <div class="module">
+      <input id="fyp" type="number" tabindex="23" min=0 max=100 placeholder="0">
+      <span>Project</span>
+    </div>
+  </section>
+
+  <section id="l7" class="hidden">
     <h2>Final Year</h2>
     <div class="module">
-      <input id="l6mark1" type="number" tabindex="7" min="0" max="100" placeholder="0">
-      <input id="l6name1" type="text" tabindex="27" placeholder="module name">
+      <input id="l7mark1" class="credits30" type="number" tabindex="24" min="0" max="100" placeholder="0">
+      <input id="l7name1" type="text" tabindex="25" placeholder="30 credit module name">
     </div>
     <div class="module">
-      <input id="l6mark2" type="number" tabindex="8" min="0" max="100" placeholder="0">
-      <input id="l6name2" type="text" tabindex="28" placeholder="module name">
+      <input id="l7mark2" class="credits30" type="number" tabindex="26" min="0" max="100" placeholder="0">
+      <input id="l7name2" type="text" tabindex="27" placeholder="30 credit module name">
     </div>
     <div class="module">
-      <input id="l6mark3" type="number" tabindex="9" min="0" max="100" placeholder="0">
-      <input id="l6name3" type="text" tabindex="29" placeholder="module name">
+      <input id="l7mark3" class="credits15" type="number" tabindex="28" min="0" max="100" placeholder="0">
+      <input id="l7name3" type="text" tabindex="29" placeholder="15 credit module name">
     </div>
     <div class="module">
-      <input id="l6mark4" type="number" tabindex="10" min="0" max="100" placeholder="0">
-      <input id="l6name4" type="text" tabindex="30" placeholder="module name">
+      <input id="l7mark4" class="credits15" type="number" tabindex="30" min="0" max="100" placeholder="0">
+      <input id="l7name4" type="text" tabindex="31" placeholder="15 credit module name">
     </div>
     <div class="module">
-      <input id="fyp" type="number" tabindex="11" min=0 max=100 placeholder="0">
-      <span>Project</span>
+      <input id="gip" type="number" tabindex="32" min=0 max=100 placeholder="0">
+      <span>Group Industrial Project</span>
     </div>
   </section>
 
@@ -104,5 +133,6 @@
 
 <script src="app.js"></script>
 <script src="js/rules.js"></script>
+<script src="js/meng_rules.js"></script>
 <script src="js/ui.js"></script>
 <script src="js/validity.js"></script>

--- a/js/meng_rules.js
+++ b/js/meng_rules.js
@@ -1,0 +1,110 @@
+/*
+
+calculate final classification based on l5/l6/l7 marks
+
+rules:
+
+a) the classification of the weighted mean from all relevant credits at Level 6 and Level 7 in the ratio of 50:50 respectively, after first discounting the marks in the worst 20 credits at Level 6 and Level 7;
+b) the classification of the weighted mean from all relevant credits at Levels 5, 6 and 7 in the ratio of 20:40:40 respectively, after first discounting the marks in the worst 20 credits at Level 5, Level 6 and Level 7.
+
+
+rules summary:
+a) (l6mean + l7mean) / 2
+b) l5mean * 0.2 + l6mean * 0.4 + l7mean * 0.4
+
+marks are an object like this:
+
+{
+  l5: [ 45, 56, 34, 75, 43, 89 ],
+  l6: [ 65, 76, 87, 67 ],
+  l7: {
+    credits15: [ 57, 83 ],
+    credits30: [ 67, 59 ],
+  }
+  fyp: 73,
+  gip: 80,
+}
+
+*/
+  
+// No need to overwrite prepareMarks function. There is no preparation for l7, since the different credit weighting means the mean needs to be worked out differently anyway
+
+function l7Mean(marks) {
+  // Becuase the l7 modules are not a multiple of 20 credits, some more work is needed to calculate the mean.
+  const marks30Credits = marks.l7.credits30.slice();
+  marks30Credits.push(marks.gip); // Group Industrial Project (gip) is a 30 credit module.
+  const marks15Credits = marks.l7.credits15.slice();
+
+  marks30Credits.sort(reverseNumericalComparison);
+  marks15Credits.sort(reverseNumericalComparison);
+  
+  const lowest30CreditModule = marks30Credits.pop();
+  const lowest15CreditModule = marks15Credits.pop();
+
+  let weighted30Credits = [];
+  let weighted15Credits = [];
+
+  if (lowest30CreditModule <= lowest15CreditModule) {
+    // Weight all the marks besides the lowest
+    weighted30Credits = marks30Credits.map(m => m * 30);
+    weighted15Credits = marks15Credits.map(m => m * 15);
+
+    weighted30Credits.push(lowest30CreditModule * 10); // Lowest scoring module was a 30 credit module, so remove 20 credits, and add to weighted array.
+
+    weighted15Credits.push(lowest15CreditModule * 15); // Lowest 20 credits have now been accounted for, so add lowest 15 credit module with normal weighting.
+  } else {
+    // Lowest scoring module was a 15 credit module. Removing this module leaves 5 credits unaccounted for, so we need to look for the next lowest module mark.
+    const secondLowest15CreditModule = marks15Credits.pop();
+    // No need to look for second lowest 30 credit module, since the lowest 30 credit module has NOT been discredited (yet).
+
+    // First, weight all the marks, except for the lowest and second lowest 15 credit module, and the lowest 30 credit module
+    weighted30Credits = marks30Credits.map(m => m * 30);
+    weighted15Credits = marks15Credits.map(m => m * 15);
+
+    if (lowest30CreditModule < secondLowest15CreditModule) {
+      weighted30Credits.push(lowest30CreditModule * 25); // The second lowest module mark was worth 30 credits, so it is now worth 25.
+      weighted15Credits.push(secondLowest15CreditModule * 15); // The second lowest 15 credit module was not the second lowest overall, so add it with normal weighting.
+    } else {
+      weighted15Credits.push(secondLowest15CreditModule * 10); // The second lowest 15 credit module was the second lowest overall, so it is now worth 10 credits.
+      weighted30Credits.push(lowest30CreditModule * 30); // The lowest 30 credit module was not the second lowest overall, so add it with normal weighting.
+    }
+  }
+
+  const allWeightedMarks = weighted15Credits.concat(weighted30Credits);
+  return sum(allWeightedMarks) / 100; // Sum of all credits is now 100, so divide by 100 for the mean
+}
+
+function sum(array) {
+  return array.reduce((a, b) => a + b, 0);
+}
+
+function ruleAMeng(marks) {
+  const l6mean = mean(marks.prepared.l6);
+  const l7mean = l7Mean(marks);
+  return roundDown(l6mean * 0.5 + l7mean * 0.5);
+}
+
+function ruleBMeng(marks) {
+  const l5mean = mean(marks.prepared.l5);
+  const l6mean = mean(marks.prepared.l6);
+  const l7mean = l7Mean(marks);
+  return roundDown(l5mean * 0.2 + l6mean * 0.4 + l7mean * 0.4);
+}
+
+function toClassificationMeng(mark) {
+  if (mark < 40) return 'Failed';
+  if (mark < 60) return 'Pass';
+  if (mark < 70) return 'with Merit';
+  return 'with Distinction';
+}
+
+
+
+/* for testing
+
+const marks = {
+    l5: [45, 56, 67, 78, 89, 90],
+    l6: [56, 67, 78, 89],
+    fyp: 68,
+}
+*/

--- a/js/rules.js
+++ b/js/rules.js
@@ -18,7 +18,12 @@ marks are an object like this:
 {
   l5: [ 45, 56, 34, 75, 43, 89 ],
   l6: [ 65, 76, 87, 67 ],
+  l7: {
+    credits15: [],
+    credits30: [],
+  }
   fyp: 73,
+  gip: null,
 }
 
 */

--- a/js/rules.js
+++ b/js/rules.js
@@ -49,11 +49,11 @@ function prepareMarks(marks) {
   marks.prepared.l5.length = 5;
 
   marks.prepared.l6 = marks.l6.slice();
+  marks.prepared.l6.push(marks.fyp);  // Add fyp once, as if it was worth 20 credits. This way, 20 credits of it can be dropped if the project is lowest
   marks.prepared.l6.sort(reverseNumericalComparison);
-  marks.prepared.l6.length = 3;
+  marks.prepared.l6.length = 4;
 
-  marks.prepared.l6.push(marks.fyp);
-  marks.prepared.l6.push(marks.fyp);
+  marks.prepared.l6.push(marks.fyp);  // Add fyp a second time, to make up the 40 credits
   marks.prepared.l6.sort(reverseNumericalComparison);
 
   // add GPA

--- a/style.css
+++ b/style.css
@@ -36,9 +36,16 @@ html {
 }
 
 
-.module :first-child {
+.module :first-child, .module .credits {
   flex-grow: 0;
+}
+
+.module :first-child {
   margin-right: .5rem;
+}
+
+.module .credits {
+  margin-left: .5rem;
 }
 
 .module span {
@@ -90,10 +97,15 @@ input:focus {
   justify-content: space-around;
 }
 
+.hidden {
+  display: none
+}
+
 
 #finalClassification,
 #gpa,
-#rules span {
+#rules span,
+.degree:checked+label {
   color: var(--hibg);
   font-weight: bold;
 }
@@ -184,4 +196,3 @@ input:focus {
     width: 100%;
   }
 }
-

--- a/style.css
+++ b/style.css
@@ -36,16 +36,9 @@ html {
 }
 
 
-.module :first-child, .module .credits {
-  flex-grow: 0;
-}
-
 .module :first-child {
+  flex-grow: 0;
   margin-right: .5rem;
-}
-
-.module .credits {
-  margin-left: .5rem;
 }
 
 .module span {


### PR DESCRIPTION
### What's Changed:
Added an integrated masters calculator. There are now radio buttons in the top left. If BSc is selected, the calculator works as before. If MEng is selected, another set of inputs is added for the 4th year, and the rules and Indications are changed to reflect what MEng classification the student would receive.

The rules for calculating MEng classification are found below, in section 5.4.5.7:
http://regulations.docstore.port.ac.uk/ExamRegs9BoardofExaminers.pdf

- Josh Reed (up847988)